### PR TITLE
doc fix: make file permission examples octal

### DIFF
--- a/docs/features/copy_file.md
+++ b/docs/features/copy_file.md
@@ -14,7 +14,7 @@ nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 		Started: true,
 	})
 
-nginxC.CopyFileToContainer(ctx, "./testdata/hello.sh", "/hello_copy.sh", 700)
+nginxC.CopyFileToContainer(ctx, "./testdata/hello.sh", "/hello_copy.sh", 0700)
 ```
 
 Or you can add a list of files in the `ContainerRequest` initialization, which can be copied before the container starts:
@@ -31,7 +31,7 @@ nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 				{
 					HostFilePath:      "./testdata/hello.sh",
 					ContainerFilePath: "/copies-hello.sh",
-					FileMode:          700,
+					FileMode:          0700,
 				},
 			},
 		},
@@ -60,7 +60,7 @@ nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 				{
 					HostFilePath:      "./testdata",    // a directory
 					ContainerFilePath: "/tmp/testdata", // important! its parent already exists
-					FileMode:          700,
+					FileMode:          0700,
 				},
 			},
 		},
@@ -73,7 +73,7 @@ if err != nil {
 // as the container is started, we can create the directory first
 _, _, err = nginxC.Exec(ctx, []string{"mkdir", "-p", "/usr/lib/my-software/config"})
 // because the container path is a directory, it will use the copy dir method as fallback
-err = nginxC.CopyFileToContainer(ctx, "./files", "/usr/lib/my-software/config/files", 700)
+err = nginxC.CopyFileToContainer(ctx, "./files", "/usr/lib/my-software/config/files", 0700)
 if err != nil {
 	// handle error
 }
@@ -94,7 +94,7 @@ nginxC, err := GenericContainer(ctx, GenericContainerRequest{
 				{
 					HostFilePath:      "./testdata",    // a directory
 					ContainerFilePath: "/tmp/testdata", // important! its parent already exists
-					FileMode:          700,
+					FileMode:          0700,
 				},
 			},
 		},
@@ -106,7 +106,7 @@ if err != nil {
 
 // as the container is started, we can create the directory first
 _, _, err = nginxC.Exec(ctx, []string{"mkdir", "-p", "/usr/lib/my-software/config"})
-err = nginxC.CopyDirToContainer(ctx, "./plugins", "/usr/lib/my-software/config/plugins", 700)
+err = nginxC.CopyDirToContainer(ctx, "./plugins", "/usr/lib/my-software/config/plugins", 0700)
 if err != nil {
 	// handle error
 }


### PR DESCRIPTION
Examples of file permissions should be in octal format. But in the code examples they are not. This PR fixes that.

<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change
-->

## What does this PR do?
Change examples in docs.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Docs should be correct.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
